### PR TITLE
Addresses: return address not script

### DIFF
--- a/src/addresses.js
+++ b/src/addresses.js
@@ -44,19 +44,24 @@ Addresses.prototype.unspents = function(addresses, offset, callback) {
   }
 
   utils.makeRequest(this.url + "unspent/" + addresses.join(','), utils.handleJSend(function(data) {
-
-    if(!Array.isArray(data)) data = [data]
+    if (!Array.isArray(data)) data = [data]
 
     var unspents = []
-    data.forEach(function(address) {
-      unspents = unspents.concat(address.unspent)
+    data.forEach(function(result) {
+      var address = result.address
+
+      result.unspent.forEach(function(unspent) {
+        unspent.address = address
+      })
+
+      unspents = unspents.concat(result.unspent)
     })
 
     return unspents.map(function(unspent) {
       return {
+        address: unspent.address,
         confirmations: unspent.confirmations,
         index: unspent.n,
-        script: unspent.script,
         txId: unspent.tx,
         value: unspent.amount
       }

--- a/test/index.js
+++ b/test/index.js
@@ -86,9 +86,11 @@ describe('Blockchain API', function() {
           results.forEach(function(result) {
             assert(result.confirmations > 0)
             assert(result.index >= 0)
-            assert(result.script !== '')
             assert(result.txId.length === 64)
             assert(result.value > 0)
+            assert.doesNotThrow(function() {
+              bitcoinjs.Address.fromBase58Check(result.address)
+            })
           })
 
           done()


### PR DESCRIPTION
Latest `common-blockchain` returns the `address` not a `script` hex.
Until a scriptPubKey based query API is available, there is no reason not to make life easier and just give us the related address.
